### PR TITLE
Type tweaks

### DIFF
--- a/src/fastapi_swagger2/models.py
+++ b/src/fastapi_swagger2/models.py
@@ -327,7 +327,7 @@ class Swagger2(BaseModel):
         Dict[str, Union[ParameterBody, ParameterNotBody, Reference]]
     ] = None
     responses: Optional[Dict[str, Union[Response, Reference]]] = None
-    securityDefinitions: Optional[Dict[str, Union[SecurityScheme, Reference]]]
+    securityDefinitions: Optional[Dict[str, Union[SecurityScheme, Reference]]] = None
     security: Optional[List[Dict[str, List[str]]]] = None
     tags: Optional[List[Tag]] = None
     externalDocs: Optional[ExternalDocumentation] = None

--- a/src/fastapi_swagger2/utils.py
+++ b/src/fastapi_swagger2/utils.py
@@ -507,22 +507,21 @@ def get_swagger2(
         # output["definitions"] = {k: definitions[k] for k in sorted(definitions)}
         output["definitions"] = {}
         for k in sorted(definitions):
-            if "properties" in definitions[k].keys():
-                properties = definitions[k]["properties"]
-                for p in properties:
-                    if "anyOf" in properties[p].keys():
-                        any_of = properties[p].pop("anyOf")
-                        if len(any_of) <= 2:
-                            for _any_of in any_of:
-                                if _any_of == {"type": "null"}:
-                                    properties[p]["x-nullable"] = True
-                                else:
-                                    properties[p].update(_any_of)
-                        else:
-                            properties[p].update({"type": "string"})
-                            logger.warning(
-                                f"fastapi_swagger2: Unable to handle anyOf in definitions {any_of}, defaulting to string type."
-                            )
+            properties = definitions[k].get("properties", [])
+            for p in properties:
+                if "anyOf" in properties[p].keys():
+                    any_of = properties[p].pop("anyOf")
+                    if len(any_of) <= 2:
+                        for _any_of in any_of:
+                            if _any_of == {"type": "null"}:
+                                properties[p]["x-nullable"] = True
+                            else:
+                                properties[p].update(_any_of)
+                    else:
+                        properties[p].update({"type": "string"})
+                        logger.warning(
+                            f"fastapi_swagger2: Unable to handle anyOf in definitions {any_of}, defaulting to string type."
+                        )
 
             output["definitions"][k] = definitions[k]
 

--- a/src/fastapi_swagger2/utils.py
+++ b/src/fastapi_swagger2/utils.py
@@ -507,20 +507,22 @@ def get_swagger2(
         # output["definitions"] = {k: definitions[k] for k in sorted(definitions)}
         output["definitions"] = {}
         for k in sorted(definitions):
-            properties = definitions[k]["properties"]
-            for p in properties:
-                if "anyOf" in properties[p].keys():
-                    any_of = properties[p].pop("anyOf")
-                    if len(any_of) <= 2:
-                        for _any_of in any_of:
-                            if _any_of == {"type": "null"}:
-                                properties[p]["x-nullable"] = True
-                            else:
-                                properties[p].update(_any_of)
-                    else:
-                        logger.warning(
-                            f"fastapi_swagger2: Unable to handle anyOf in definitions {any_of}"
-                        )
+            if "properties" in definitions[k].keys():
+                properties = definitions[k]["properties"]
+                for p in properties:
+                    if "anyOf" in properties[p].keys():
+                        any_of = properties[p].pop("anyOf")
+                        if len(any_of) <= 2:
+                            for _any_of in any_of:
+                                if _any_of == {"type": "null"}:
+                                    properties[p]["x-nullable"] = True
+                                else:
+                                    properties[p].update(_any_of)
+                        else:
+                            properties[p].update({"type": "string"})
+                            logger.warning(
+                                f"fastapi_swagger2: Unable to handle anyOf in definitions {any_of}, defaulting to string type."
+                            )
 
             output["definitions"][k] = definitions[k]
 


### PR DESCRIPTION
This has a couple small tweaks:

 - things like Enums don't have properties in their definition, so wrapped the property logic in a key check
 - for anyOf types that can't be handled simply, set the type as `string` so that it's not entirely missing a type.
 - allow for the case where there are zero security definitions, as mentioned in https://github.com/virajkanwade/fastapi_swagger2/issues/2
 